### PR TITLE
Macrocosm compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-sudo: false
-before_install:
-  # https://github.com/travis-ci/travis-ci/issues/3225
-  - mkdir travis-phantomjs
-  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
-before_script: make

--- a/js/id/core/connection.js
+++ b/js/id/core/connection.js
@@ -282,7 +282,7 @@ iD.Connection = function(useHttps) {
             var osmChangeJXON = JXON.stringify(connection.osmChangeJXON(changeset_id, changes));
             d3.xhr(url + '/api/0.6/changeset/' + changeset_id + '/upload')
             .header('Content-Type', 'text/xml')
-            .send('POST', osmChangeJXON, function (err, resp) {
+            .send('POST', osmChangeJXON, function (err) {
                 if (err) return callback(err);
                 callback(null, changeset_id);
             });


### PR DESCRIPTION
1. Use d3.xhr instead of oauth.js to propagate changesets.
2. Puts user id, display name in changeset.
3. Points url at local macrocosm setup.
4. Remove `.travis.yml`
